### PR TITLE
tty palette wasn't set properly

### DIFF
--- a/blugon.py
+++ b/blugon.py
@@ -433,7 +433,7 @@ def call_tty(r, g, b):
         def flt_to_hex(flt):
             if flt > 255:
                 flt = 255
-            return format(int(flt), 'x')
+            return format(int(flt), '0=2x')
         hex_r = flt_to_hex(r * int(color[0:2], 16))
         hex_g = flt_to_hex(g * int(color[2:4], 16))
         hex_b = flt_to_hex(b * int(color[4:6], 16))


### PR DESCRIPTION
due to no zero padding, or, no leading zeroes, for the hex conversion, the format for [`ESC]Pcrrggbb`](https://github.com/jumper149/blugon/blob/baf79b5b19f3387b4186fc5dacd31a7c47e22144/backends/tty/tty.sh#L3) wasn't respected, passed args for 3000 Kelvin for `/usr/lib/blugon/tty.sh` would be:
```
0000
1aa00
20760
3aa3b0
40049
5aa049
607649
7aa7649
8553b24
9ff3b24
A55b124
Bffb124
C553b6d
Dff3b6d
E55b16d
Fffb16d
```
instead of(with this patch):
```
0000000
1aa0000
2007600
3aa3b00
4000049
5aa0049
6007649
7aa7649
8553b24
9ff3b24
A55b124
Bffb124
C553b6d
Dff3b6d
E55b16d
Fffb16d
```