### PR TITLE
Disable argument

### DIFF
--- a/bash-completion/blugon
+++ b/bash-completion/blugon
@@ -21,7 +21,8 @@ _blugon () {
 		"-c" "--configdir"
 		"-b" "--backend"
 		"-w" "--waitforx"
-	)
+        "-d" "--disable"	
+    )
 
 	backends=(
 		"xgamma"

--- a/blugon.1
+++ b/blugon.1
@@ -20,6 +20,7 @@ blugon \- simple Blue Light Filter for X
 .RB [\|\-b
 .IR backend \|]
 .RB [\|\-w\|]
+.RB [\|\-d\|]
 
 .SH DESCRIPTION
 blugon is a simple blue light filter that uses xgamma as a backed and is configured in "$XDG_CONFIG_HOME/blugon/" or "$HOME/.config/blugon/" as fallback.
@@ -117,6 +118,10 @@ Available backends are:
 .B \-w, \-\-waitforx
 Instead of crashing when the backend fails the program will continue.
 This is automatically used by the systemd service to prevent failing when switching to another TTY.
+.TP
+.B \-d, \-\-disable
+Turn off blue filter and exit.
+Works if other instances of blugon're not running.
 
 .SH EXAMPLES
 To just apply the blue filter and then exit use:

--- a/blugon.py
+++ b/blugon.py
@@ -106,6 +106,8 @@ argparser.add_argument('-b', '--backend', nargs='?',
         dest='backend', type=str, help='set backend (default: '+BACKEND+')')
 argparser.add_argument('-w', '--waitforx', action='store_true',
         dest='wait_for_x', help='continue when backend fails')
+argparser.add_argument('-d', '--disable', action='store_true',
+        dest='disable', help='turn off blue filter')
 
 args = argparser.parse_args()
 
@@ -182,6 +184,7 @@ confs = confparser['main']
 #----------------------------------------------------------------------ARGUMENTS
 
 ONCE = args.once
+DISABLE = args.disable
 
 MIN_CURRENT_TEMP = confparser['current'].getfloat('min_temp')
 MAX_CURRENT_TEMP = confparser['current'].getfloat('max_temp')
@@ -547,10 +550,16 @@ def main():
                 call_backend(BACKEND, red_gamma, green_gamma, blue_gamma)
             time.sleep(sleep_time)
 
+    if DISABLE:
+        try:
+            call_backend(BACKEND, 1, 1, 1) 
+        except:
+            verbose_print('X-server not found, cancel fading')
+        return
+
     if ONCE:
         while_body(get_minute(), 0)
         exit()
-
 
     while True :
         while_body(get_minute(), INTERVAL)


### PR DESCRIPTION
If blugon doesn't work in another process `--disable` turns off the blue filter.
It works if blugon is running, but it is "filter race".