### PR TITLE
Allow overriding C compiler

### DIFF
--- a/backends/scg/Makefile
+++ b/backends/scg/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 CFLAGS = -O2 -std=c11 -D_POSIX_C_SOURCE=200809L -Wall -Wextra -Wpedantic -I/usr/X11R6/include
 LDFLAGS = -L/usr/X11R6/lib
 LDLIBS = -lX11 -lXrandr


### PR DESCRIPTION
Allows use of non-GNU (e.g. clang) C compilers