### PR TITLE
Implement per-monitor settings

### DIFF
--- a/backends/scg/scg.c
+++ b/backends/scg/scg.c
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <X11/Xlib.h>
 #include <X11/extensions/Xrandr.h>
 
@@ -15,9 +16,24 @@ double parse_arg(const char *arg) {
     return gamma;
 }
 
-int main(int argc, char **argv) {
-    if (argc != 4) {
+int parse_int_arg(const char *arg) {
+    errno = 0;
+    int num = strtol(arg, NULL, 10);
+    if (errno) {
+        perror("strtol");
         exit(EXIT_FAILURE);
+    }
+
+    return num;
+}
+
+int main(int argc, char **argv) {
+    char *output = NULL;
+    if (argc < 4 || argc > 5) {
+        exit(EXIT_FAILURE);
+    }
+    if (argc >= 5) {
+        output = argv[4];
     }
 
     double gamma_r = parse_arg(argv[1]);
@@ -32,8 +48,24 @@ int main(int argc, char **argv) {
     Window root = XDefaultRootWindow(dpy);
     XRRScreenResources *res = XRRGetScreenResourcesCurrent(dpy, root);
 
+    RRCrtc output_crtc = 0;
+    if (output != NULL) {
+        for (int m = 0; m < res->noutput; m++) {
+            XRROutputInfo *oi = XRRGetOutputInfo(dpy, res, res->outputs[m]);
+            if (!strcmp(oi->name, output))
+                output_crtc = oi->crtc;
+            XRRFreeOutputInfo(oi);
+        }
+        if (!output_crtc) {
+            fprintf(stderr, "could not find crtc for output %s\n", output);
+            exit(EXIT_FAILURE);
+        }
+    }
+
     for (int c = 0; c < res->ncrtc; c++) {
         RRCrtc crtc = res->crtcs[c];
+        if (output_crtc && crtc != output_crtc)
+            continue;
         int size = XRRGetCrtcGammaSize(dpy, crtc);
         XRRCrtcGamma *crtc_gamma = XRRAllocGamma(size);
 

--- a/blugon.py
+++ b/blugon.py
@@ -106,6 +106,8 @@ argparser.add_argument('-b', '--backend', nargs='?',
         dest='backend', type=str, help='set backend (default: '+BACKEND+')')
 argparser.add_argument('-w', '--waitforx', action='store_true',
         dest='wait_for_x', help='continue when backend fails')
+argparser.add_argument('-O', '--output', nargs='?',
+        dest='output', help='operate on a specific output')
 
 args = argparser.parse_args()
 
@@ -206,6 +208,10 @@ if args.backend:
     BACKEND = args.backend
 if not BACKEND in BACKEND_LIST:
     raise ValueError('backend not found, choose from:\n    ' + '\n    '.join(BACKEND_LIST))
+
+OUTPUT = confs.get('output')
+if args.output:
+    OUTPUT = args.output
 
 WAIT_FOR_X = confs.getboolean('wait_for_x')
 if args.wait_for_x:
@@ -423,7 +429,10 @@ def call_xgamma(r, g, b):
 
 def call_scg(r, g, b):
     """Start a subprocess of backend scg from Gamma values"""
-    check_call([MAKE_INSTALL_PREFIX + '/lib/blugon/scg', str(r), str(g), str(b)])
+    argv = [MAKE_INSTALL_PREFIX + '/lib/blugon/scg', str(r), str(g), str(b)]
+    if (OUTPUT):
+        argv.append(OUTPUT)
+    check_call(argv)
     return
 
 def call_tty(r, g, b):


### PR DESCRIPTION
With this patch, the `-O output` option will instruct blugon to affect only the specified XRandR output, allowing displays (CRTCs, technically) to be controlled independently.  (Only supported by the scg backend.)